### PR TITLE
Issue 5 (https://github.com/tim-reynolds/magento-qconfig/issues/5) Searc...

### DIFF
--- a/src/app/code/community/Treynolds/Qconfig/Helper/Data.php
+++ b/src/app/code/community/Treynolds/Qconfig/Helper/Data.php
@@ -46,7 +46,7 @@ class Treynolds_Qconfig_Helper_Data extends Mage_Core_Helper_Abstract {
             $path[] = $current;
             /* The count is 4 when we matched a 'group' label */
             if(count($path)==4){
-                $group_ret[] = $path[3]. '_' . $path[1] . '-head';
+                $group_ret[] = $path[3]. '_' . $path[1];
             }
             /* The count is 6 when we match a 'field' label */
             else if(count($path)==6) {

--- a/src/js/treynolds/qconfig.js
+++ b/src/js/treynolds/qconfig.js
@@ -95,6 +95,11 @@ Qconfig.prototype = {
             if (t.next() != null && t.next().hasClassName('treynolds_active')) {
                 t.addClassName('treynolds_top');
             }
+            if(t.hasClassName('entry-edit-head')){
+                var count = t.up().select('.form-list .treynolds_active').length ;
+                var span = new Element('span', {'class':'treynolds_qconfig_field_count'}).update(count + ' Field'+(count==1?' Matches':'s Match'));
+                t.select('a')[0].insert(span);
+            }
         });
     },
     onescape:function(){
@@ -129,6 +134,11 @@ Qconfig.prototype = {
         $$('.treynolds_searching').each(
             function (elm) {
                 elm.removeClassName('treynolds_searching');
+            }
+        );
+        $$('.treynolds_qconfig_field_count').each(
+            function(elm){
+                elm.remove();
             }
         );
     }

--- a/src/skin/adminhtml/base/default/treynolds/qconfig.css
+++ b/src/skin/adminhtml/base/default/treynolds/qconfig.css
@@ -53,6 +53,15 @@
     transition: all 0.5s ease;
 }
 
+.treynolds_qconfig_field_count {
+    float: right;
+    text-align: center;
+    padding: 0 7px;
+    margin-right: 25px;
+    background: url(../../../default/default/images/nav1_active.gif) center center no-repeat;
+    border-radius: 8px;
+
+}
 #system_config_tabs.treynolds_searching dd a ,
 #system_config_tabs.treynolds_searching dd a:hover {
     background: #929292 none;


### PR DESCRIPTION
...h for email shows match on nav, but nothing on groups/fields.

This was a bug, where I was adding '-head' in PHP land and JS land. Fixed.

Also added display on the group letting you know how many fields match.
